### PR TITLE
Fix some oddities in default_settings.txt

### DIFF
--- a/default_settings.txt
+++ b/default_settings.txt
@@ -7,7 +7,6 @@ Scenario.name = default_scenario
 Scenario.simulateConnections = true
 Scenario.updateInterval = 0.1
 # 43200s == 12h
-Scenario.endTime = 10000000
 Scenario.endTime = 43200
 
 ## Interface-specific settings:
@@ -26,7 +25,7 @@ btInterface.transmitRange = 10
 # High speed, long range, interface for group 4
 highspeedInterface.type = SimpleBroadcastInterface
 highspeedInterface.transmitSpeed = 10M
-highspeedInterface.transmitRange = 10
+highspeedInterface.transmitRange = 1000
 
 # Define 6 different node groups
 Scenario.nrofHostGroups = 6
@@ -122,7 +121,7 @@ Events1.interval = 25,35
 # Message sizes (500kB - 1MB)
 Events1.size = 500k,1M
 # range of message source/destination addresses
-Events1.hosts = 0,125
+Events1.hosts = 0,126
 # Message ID prefix
 Events1.prefix = M
 
@@ -152,8 +151,8 @@ Report.warmup = 0
 # default directory of reports (can be overridden per Report with output setting)
 Report.reportDir = reports/
 # Report classes to load
-Report.report1 = ContactTimesReport
-Report.report2 = ConnectivityONEReport
+Report.report1 = MessageStatsReport
+Report.report2 = ContactTimesReport
 
 ## Default settings for some routers settings
 ProphetRouter.secondsInTimeUnit = 30


### PR DESCRIPTION
The default_settings.txt included in v1.6.0 has some differences to the config in v.1.5.1-RC2, and some of these differences appear to be in error. These are just minor changes and have been tested to make sure they still work when executed on the simulator.
- There's a duplicate entry for Scenario.endTime (removed in this commit)
- highspeedInterface.transmitRange decreased from 1000 to 10 (reset back to 1000 in this commit)
- The host range for the MessageEventGenerator was shrunk from 0,126 to 0,125 (reset back to 0,126 in this commit)
- The MessageStatsReport was replaced with the ContactTimesReport, and the ConnectivityONEReport was added. In this commit, the MessageStatsReport was reinstated in place of the ConnectivityONEReport, and the ContactTimesReport was kept in place.
