### PR TITLE
Added support for message drop policies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ doc/package-list
 .project
 /target/
 .settings/org.eclipse.*
+/bin/

--- a/compile.bat
+++ b/compile.bat
@@ -2,7 +2,7 @@ set targetdir=target
 
 IF NOT EXIST "%targetdir%" mkdir %targetdir%
 
-javac -sourcepath src -d %targetdir% -extdirs lib/ src/core/*.java src/movement/*.java src/report/*.java src/routing/*.java src/gui/*.java src/input/*.java src/applications/*.java src/interfaces/*.java
+javac -sourcepath src -d %targetdir% -extdirs lib/ src/core/*.java src/movement/*.java src/report/*.java src/routing/*.java src/gui/*.java src/input/*.java src/applications/*.java src/interfaces/*.java src/buffermanagement/*.java
 
 
 

--- a/compile.sh
+++ b/compile.sh
@@ -2,7 +2,7 @@ targetdir=target
 
 if [ ! -d "$targetdir" ]; then mkdir $targetdir; fi
 
-javac -sourcepath src -d $targetdir -extdirs lib/ src/core/*.java src/movement/*.java src/report/*.java src/routing/*.java src/gui/*.java src/input/*.java src/applications/*.java src/interfaces/*.java
+javac -sourcepath src -d $targetdir -extdirs lib/ src/core/*.java src/movement/*.java src/report/*.java src/routing/*.java src/gui/*.java src/input/*.java src/applications/*.java src/interfaces/*.java src/buffermanagement/*.java
 
 if [ ! -d "$targetdir/gui/buttonGraphics" ]; then cp -R src/gui/buttonGraphics target/gui/; fi
 	

--- a/default_settings.txt
+++ b/default_settings.txt
@@ -41,6 +41,8 @@ Scenario.nrofHostGroups = 6
 # router: router used to route messages (valid class name from routing package)
 # activeTimes: Time intervals when the nodes in the group are active (start1, end1, start2, end2, ...)
 # msgTtl : TTL (minutes) of the messages created by this host group, default=infinite
+# dropPolicy: if specified a custom drop policy is used (see the classes in the buffermanagement package).
+# dropMsgBeingSent: define if the custom drop policy is allowed to drop messages being sent.
 
 ## Group and movement model specific settings
 # pois: Points Of Interest indexes and probabilities (poiIndex1, poiProb1, poiIndex2, poiProb2, ... )

--- a/src/buffermanagement/DropPolicy.java
+++ b/src/buffermanagement/DropPolicy.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016 Aalto University, ComNet
+ * Released under GPLv3. See LICENSE.txt for details.
+ */
+
+package buffermanagement;
+
+import core.Message;
+import core.Settings;
+import routing.ActiveRouter;
+
+
+/**
+ * Defines the basic structure for implementing a message drop policy. These policies can be used by the hosts
+ * when their buffers haven't enough space to receive an incoming message.
+ */
+public abstract class DropPolicy {
+	
+	/**
+	 * Drop message being sent -setting id ({@value}). The configuration that defines
+	 * if messages being sent can be dropped.
+	 */
+	private static final String DROP_MSG_BEING_SENT = "dropMsgBeingSent";
+	
+	/**
+	 * Defines if messages being sent can be dropped.
+	 */
+	protected boolean dropMsgBeingSent = true;
+	
+	/**
+	 * Constructor with the signature required to be instantiated by the simulator.
+	 * @param s
+	 */
+	public DropPolicy(Settings s) {
+		if (s.contains(DROP_MSG_BEING_SENT)) {
+			this.dropMsgBeingSent = s.getBoolean(DROP_MSG_BEING_SENT);
+		}
+	}
+	
+	/**
+	 * Try to remove messages from the buffer until enough space for receive the incoming message is freed.
+	 * @param router A reference to the receiver router.
+	 * @param incomingMessage The incoming message.
+	 * @return True if it was possible to freed enough space, false otherwise.
+	 */
+	public abstract boolean makeRoomForMessage(ActiveRouter router, Message incomingMessage);
+}

--- a/src/buffermanagement/EDropPolicy.java
+++ b/src/buffermanagement/EDropPolicy.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2016 Aalto University, ComNet
+ * Released under GPLv3. See LICENSE.txt for details.
+ */
+
+package buffermanagement;
+
+import java.util.Iterator;
+import core.Message;
+import core.Settings;
+import routing.ActiveRouter;
+
+/**
+ * Implementation of the E-Drop policy as proposed in the paper 
+ * "E-DROP: An Effective Drop Buffer Management Policy for DTN Routing Protocols"
+ * that can be found at 
+ * http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.206.3719&rep=rep1&type=pdf
+ */
+public class EDropPolicy extends DropPolicy {
+
+	/**
+	 * Store a settings reference to pass to FIFO constructor when needed.
+	 */
+	private Settings settings;
+	
+	public EDropPolicy(Settings s) {
+		super(s);
+		this.settings = s;
+		
+		// It doesn't need specific settings.
+	}
+
+	@Override
+	public boolean makeRoomForMessage(ActiveRouter router, Message incomingMessage) {
+		
+		int size = incomingMessage == null ? 0 : incomingMessage.getSize();
+		
+		if (size > router.getBufferSize()) {
+			return false; // message too big for the buffer
+		}
+		
+		long freeBuffer = router.getFreeBufferSize();
+		
+		while (freeBuffer < size) {
+			Iterator<Message> iter = router.getMessageCollection().iterator();
+			
+			if (!iter.hasNext()) {
+				return false; // There is no message that can be dropped
+			}
+			
+			// Try to find a message with size greater or equals to the incoming message size
+			Message msg = null;
+			while (iter.hasNext()) {
+				Message temp = iter.next();
+				if (temp.getSize() >= size && (this.dropMsgBeingSent || !router.isSending(temp.getId()))) {
+					msg = temp;
+					break;
+				}
+			}
+			
+			// If there is a message to drop
+			if (msg != null) {
+				router.deleteMessage(msg.getId(), true);
+				freeBuffer += msg.getSize();
+			}
+			else {
+				// If there aren't messages with size equals or greater than the incoming, works like FIFO
+				FIFODropPolicy fifo = new FIFODropPolicy(this.settings);
+				return fifo.makeRoomForMessage(router, incomingMessage);
+			}
+		}
+		return true;
+	}
+	
+
+}

--- a/src/buffermanagement/FIFODropPolicy.java
+++ b/src/buffermanagement/FIFODropPolicy.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2016 Aalto University, ComNet
+ * Released under GPLv3. See LICENSE.txt for details.
+ */
+
+package buffermanagement;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+
+import core.Message;
+import core.Settings;
+import routing.ActiveRouter;
+
+/**
+ * Drop the messages that arrived first, i.e., the messages that have the minimum
+ * receive time.
+ */
+public class FIFODropPolicy extends DropPolicy{
+
+	public FIFODropPolicy(Settings s) {
+		super(s);
+		// It doesn't need specific settings.
+	}
+
+	@Override
+	public boolean makeRoomForMessage(ActiveRouter router, Message incomingMessage) {
+		
+		int size = incomingMessage == null ? 0 : incomingMessage.getSize();
+		
+		// Check if the incoming message size exceeds the buffer capacity
+		if (size > router.getBufferSize()) {
+			return false;
+		}
+		
+		long freeBuffer = router.getFreeBufferSize();
+		
+		// Check if there is enough space to receive the message before sorting the buffer
+		if (freeBuffer >= size) {
+			return true;
+		}
+		
+		// Sort the messages by receive time
+		ArrayList<Message> messages = new ArrayList<Message>(router.getMessageCollection());
+		Collections.sort(messages, new FIFOComparator());
+		
+		/* Delete messages from the buffer until there is enough space */
+		while (freeBuffer < size) {
+			
+			if (messages.size() == 0) {
+				return false; // couldn't remove more messages
+			}
+			
+			// Get the message that was received first
+			Message msg = messages.remove(0);
+			
+			// Check if the router is sending this message
+			if (this.dropMsgBeingSent || !router.isSending(msg.getId())) {
+				// Delete the message and send signal "drop"
+				router.deleteMessage(msg.getId(), true);
+				freeBuffer += msg.getSize();
+			}
+		}
+		
+		return true;
+	}
+	
+	private class FIFOComparator implements Comparator<Message> {
+
+		@Override
+		public int compare(Message m1, Message m2) {
+			return ((Double)m1.getReceiveTime()).compareTo(m2.getReceiveTime());
+		}
+		
+	}
+
+}

--- a/src/buffermanagement/MOFODropPolicy.java
+++ b/src/buffermanagement/MOFODropPolicy.java
@@ -27,7 +27,7 @@ public class MOFODropPolicy extends DropPolicy {
 	@Override
 	public boolean makeRoomForMessage(ActiveRouter router, Message incomingMessage) {
 		
-		int size = incomingMessage.getSize();
+		int size = incomingMessage == null ? 0 : incomingMessage.getSize();
 		
 		if (size > router.getBufferSize()) {
 			return false; // message too big for the buffer

--- a/src/buffermanagement/MOFODropPolicy.java
+++ b/src/buffermanagement/MOFODropPolicy.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2016 Aalto University, ComNet
+ * Released under GPLv3. See LICENSE.txt for details.
+ */
+
+package buffermanagement;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import core.Message;
+import core.Settings;
+import routing.ActiveRouter;
+
+/**
+ * Drop the messages with the maximum number of transmissions first, i.e., the most forwarded 
+ * messages.
+ */
+public class MOFODropPolicy extends DropPolicy {
+
+
+	public MOFODropPolicy(Settings s) {
+		super(s);
+		// It doesn't need specific settings.
+	}
+
+	@Override
+	public boolean makeRoomForMessage(ActiveRouter router, Message incomingMessage) {
+		
+		int size = incomingMessage.getSize();
+		
+		if (size > router.getBufferSize()) {
+			return false; // message too big for the buffer
+		}
+		
+		long freeBuffer = router.getFreeBufferSize();
+		
+		// Check if there is enough space to receive the message before sorting the buffer
+		if (freeBuffer >= size) {
+			return true;
+		}
+		
+		// Sort the messages by forward count
+		ArrayList<Message> messages = new ArrayList<Message>(router.getMessageCollection());
+		Collections.sort(messages, new MOFOComparator());
+		
+		/* Delete messages from the buffer until there is enough space */
+		while (freeBuffer < size) {
+			
+			if (messages.size() == 0) {
+				return false; // couldn't remove more messages
+			}
+			
+			// Get the message that was most forwarded
+			Message msg = messages.remove(messages.size()-1);
+			
+			// Check if the router is sending this message
+			if (this.dropMsgBeingSent || !router.isSending(msg.getId())) {
+				// Delete the message and send signal "drop"
+				router.deleteMessage(msg.getId(), true);
+				freeBuffer += msg.getSize();
+			}
+		}
+		
+		return true;
+		
+	}
+	
+	private class MOFOComparator implements Comparator<Message> {
+
+		@Override
+		public int compare(Message msg0, Message msg1) {
+			return ((Integer)msg0.getForwardCount()).compareTo(msg1.getForwardCount());
+		}
+		
+	}
+
+}

--- a/src/buffermanagement/PassiveDropPolicy.java
+++ b/src/buffermanagement/PassiveDropPolicy.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 Aalto University, ComNet
+ * Released under GPLv3. See LICENSE.txt for details.
+ */
+
+package buffermanagement;
+
+import core.Message;
+import core.Settings;
+import routing.ActiveRouter;
+
+/**
+ * This implementation always refuses to drop a message. It can be used for specific tests.
+ */
+public class PassiveDropPolicy extends DropPolicy{
+
+	public PassiveDropPolicy(Settings s) {
+		super(s);
+		// It doesn't need specific settings.
+	}
+
+	@Override
+	public boolean makeRoomForMessage(ActiveRouter router, Message incomingMessage) {
+		
+		// Get the incoming message size.
+		int size = incomingMessage == null ? 0 : incomingMessage.getSize();
+		
+		// Get the available space.
+		long freeBuffer = router.getFreeBufferSize();
+		
+		// Return if it is possible to receive the incoming message, it does not drop any messages
+		return size <= freeBuffer;
+	}
+	
+}

--- a/src/buffermanagement/SHLIDropPolicy.java
+++ b/src/buffermanagement/SHLIDropPolicy.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2016 Aalto University, ComNet
+ * Released under GPLv3. See LICENSE.txt for details.
+ */
+
+package buffermanagement;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+
+import core.Message;
+import core.Settings;
+import routing.ActiveRouter;
+
+public class SHLIDropPolicy extends DropPolicy {
+
+	public SHLIDropPolicy(Settings s) {
+		super(s);
+		// It doesn't need specific settings.
+	}
+
+	@Override
+	public boolean makeRoomForMessage(ActiveRouter router, Message incomingMessage) {
+		
+		int size = incomingMessage == null ? 0 : incomingMessage.getSize();
+		
+		if (size > router.getBufferSize()) {
+			return false; // Message too big for the buffer
+		}
+		
+		long freeBuffer = router.getFreeBufferSize();
+		
+		// Check if there is enough space to receive the message before sorting the buffer
+		if (freeBuffer >= size) {
+			return true;
+		}
+		
+		// Sort the messages by ttl
+		ArrayList<Message> messages = new ArrayList<Message>(router.getMessageCollection());
+		Collections.sort(messages, new SHLIComparator());
+		
+		/* delete messages from the buffer until there's enough space */
+		while (freeBuffer < size) {
+			
+			if (messages.size() == 0) {
+				return false; // Couldn't remove more messages
+			}
+			
+			// Get the message with minimum ttl
+			Message msg = messages.remove(0);
+			
+			// Check if the router is sending this message
+			if (this.dropMsgBeingSent || !router.isSending(msg.getId())) {
+				router.deleteMessage(msg.getId(), true);
+				freeBuffer += msg.getSize();
+			}
+		}
+		return true;
+		
+	}
+	
+	private class SHLIComparator implements Comparator<Message> {
+
+		@Override
+		public int compare(Message msg0, Message msg1) {
+			return ((Integer)msg0.getTtl()).compareTo(msg1.getTtl());
+		}
+		
+	}
+	
+	
+
+}

--- a/src/core/Message.java
+++ b/src/core/Message.java
@@ -34,6 +34,9 @@ public class Message implements Comparable<Message> {
 	private double timeCreated;
 	/** Initial TTL of the message */
 	private int initTtl;
+	
+	/** Stores how many times the message was forwarded to other hosts **/
+	private int forwardCount;
 
 	/** if a response to this message is required, this is the size of the
 	 * response message (or 0 if no response is requested) */
@@ -358,6 +361,28 @@ public class Message implements Comparable<Message> {
 	 */
 	public void setAppID(String appID) {
 		this.appID = appID;
+	}
+	
+	/**
+	 * Must be called every time the message is forwarded.
+	 */
+	public void incrementForwardCount() {
+		this.forwardCount++;
+	}
+	
+	/**
+	 * Return how many times the message was forwarded.
+	 */
+	public int getForwardCount() {
+		return this.forwardCount;
+	}
+	
+	/**
+	 * Should be used only by the unit tests to create specific scenarios.
+	 * @param fc New value for forward count.
+	 */
+	public void setForwardCount(int fc) {
+		this.forwardCount = fc;
 	}
 
 }

--- a/src/routing/ActiveRouter.java
+++ b/src/routing/ActiveRouter.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 
+import buffermanagement.DropPolicy;
 import routing.util.EnergyModel;
 import routing.util.MessageTransferAcceptPolicy;
 import routing.util.RoutingInfo;
@@ -36,6 +37,12 @@ public abstract class ActiveRouter extends MessageRouter {
 	/** should messages that final recipient marks as delivered be deleted
 	 * from message buffer */
 	protected boolean deleteDelivered;
+	
+	/**
+	 * Drop policy -setting id ({@value}). The class name used as the drop
+	 * policy implementation.
+	 */
+	public static final String DROP_POLICY_S = "dropPolicy";
 
 	/** prefix of all response message IDs */
 	public static final String RESPONSE_PREFIX = "R_";
@@ -48,6 +55,11 @@ public abstract class ActiveRouter extends MessageRouter {
 
 	private MessageTransferAcceptPolicy policy;
 	private EnergyModel energy;
+	
+	/**
+	 * The drop policy used by the router.
+	 */
+	private DropPolicy dropPolicy;
 
 	/**
 	 * Constructor. Creates a new message router based on the settings in
@@ -60,6 +72,15 @@ public abstract class ActiveRouter extends MessageRouter {
 		this.policy = new MessageTransferAcceptPolicy(s);
 
 		this.deleteDelivered = s.getBoolean(DELETE_DELIVERED_S, false);
+		
+		// Create a drop policy object if it is specified in the settings.
+		if (s.contains(DROP_POLICY_S)) {
+			String dropPolicyClass = s.getSetting(DROP_POLICY_S);
+			this.dropPolicy = (DropPolicy) s.createIntializedObject("buffermanagement." + dropPolicyClass);
+		}
+		else {
+			this.dropPolicy = null;
+		}
 
 		if (s.contains(EnergyModel.INIT_ENERGY_S)) {
 			this.energy = new EnergyModel(s);
@@ -77,6 +98,7 @@ public abstract class ActiveRouter extends MessageRouter {
 		this.deleteDelivered = r.deleteDelivered;
 		this.policy = r.policy;
 		this.energy = (r.energy != null ? r.energy.replicate() : null);
+		this.dropPolicy = r.dropPolicy; // The hosts of the same group share a single instance of drop policy
 	}
 
 	@Override
@@ -122,7 +144,7 @@ public abstract class ActiveRouter extends MessageRouter {
 
 	@Override
 	public boolean createNewMessage(Message m) {
-		makeRoomForNewMessage(m.getSize());
+		makeRoomForNewMessage(m);
 		return super.createNewMessage(m);
 	}
 
@@ -251,7 +273,7 @@ public abstract class ActiveRouter extends MessageRouter {
 		}
 
 		/* remove oldest messages but not the ones being sent */
-		if (!makeRoomForMessage(m.getSize())) {
+		if (!makeRoomForMessage(m)) {
 			return DENIED_NO_SPACE; // couldn't fit into buffer -> reject
 		}
 
@@ -261,11 +283,18 @@ public abstract class ActiveRouter extends MessageRouter {
 	/**
 	 * Removes messages from the buffer (oldest first) until
 	 * there's enough space for the new message.
-	 * @param size Size of the new message
-	 * transferred, the transfer is aborted before message is removed
+	 * @param incomingMessage The message that needs to be stored in the buffer.
 	 * @return True if enough space could be freed, false if not
 	 */
-	protected boolean makeRoomForMessage(int size){
+	protected boolean makeRoomForMessage(Message incomingMessage){
+		
+		// Check if a custom drop policy is specified
+		if (this.dropPolicy != null) {
+			return this.dropPolicy.makeRoomForMessage(this, incomingMessage);
+		}
+		
+		int size = incomingMessage == null ? 0 : incomingMessage.getSize();
+		
 		if (size > this.getBufferSize()) {
 			return false; // message too big for the buffer
 		}
@@ -305,10 +334,10 @@ public abstract class ActiveRouter extends MessageRouter {
 	 * calls {@link #makeRoomForMessage(int)} and ignores the return value.
 	 * Therefore, if the message can't fit into buffer, the buffer is only
 	 * cleared from messages that are not being sent.
-	 * @param size Size of the new message
+	 * @param msg The new message
 	 */
-	protected void makeRoomForNewMessage(int size) {
-		makeRoomForMessage(size);
+	protected void makeRoomForNewMessage(Message msg) {
+		makeRoomForMessage(msg);
 	}
 
 
@@ -607,7 +636,7 @@ public abstract class ActiveRouter extends MessageRouter {
 			if (removeCurrent) {
 				// if the message being sent was holding excess buffer, free it
 				if (this.getFreeBufferSize() < 0) {
-					this.makeRoomForMessage(0);
+					this.makeRoomForMessage(null);
 				}
 				sendingConnections.remove(i);
 			}
@@ -645,7 +674,12 @@ public abstract class ActiveRouter extends MessageRouter {
 	 * Subclasses that are interested of the event may want to override this.
 	 * @param con The connection whose transfer was finalized
 	 */
-	protected void transferDone(Connection con) { }
+	protected void transferDone(Connection con) { 
+		// Use the connection copy of the message to retrieve the 
+		// local copy of the message and then increment the forward count
+		Message msg = this.getMessage(con.getMessage().getId());
+		msg.incrementForwardCount();
+	}
 
 	@Override
 	public RoutingInfo getRoutingInfo() {
@@ -655,6 +689,14 @@ public abstract class ActiveRouter extends MessageRouter {
 					String.format("%.2f", energy.getEnergy())));
 		}
 		return top;
+	}
+	
+	/**
+	 * Used by the unit tests to verify what drop policy is active.
+	 * @return The current drop policy.
+	 */
+	public DropPolicy getDropPolicy() {
+		return this.dropPolicy;
 	}
 
 }

--- a/src/routing/ActiveRouter.java
+++ b/src/routing/ActiveRouter.java
@@ -678,7 +678,8 @@ public abstract class ActiveRouter extends MessageRouter {
 		// Use the connection copy of the message to retrieve the 
 		// local copy of the message and then increment the forward count
 		Message msg = this.getMessage(con.getMessage().getId());
-		msg.incrementForwardCount();
+		if (msg != null)
+			msg.incrementForwardCount();
 	}
 
 	@Override

--- a/src/routing/EpidemicOracleRouter.java
+++ b/src/routing/EpidemicOracleRouter.java
@@ -138,7 +138,7 @@ public class EpidemicOracleRouter extends ActiveRouter {
 		}
 
 		/* remove oldest messages but not the ones being sent */
-		if (!makeRoomForMessage(m.getSize())) {
+		if (!makeRoomForMessage(m)) {
 			return DENIED_NO_SPACE; // couldn't fit into buffer -> reject
 		}
 

--- a/src/routing/SprayAndWaitRouter.java
+++ b/src/routing/SprayAndWaitRouter.java
@@ -77,7 +77,7 @@ public class SprayAndWaitRouter extends ActiveRouter {
 
 	@Override
 	public boolean createNewMessage(Message msg) {
-		makeRoomForNewMessage(msg.getSize());
+		makeRoomForNewMessage(msg);
 
 		msg.setTtl(this.msgTtl);
 		msg.addProperty(MSG_COUNT_PROPERTY, new Integer(initialNrofCopies));

--- a/src/test/AbstractDropPolicyTest.java
+++ b/src/test/AbstractDropPolicyTest.java
@@ -1,0 +1,44 @@
+package test;
+
+import routing.EpidemicRouter;
+
+public class AbstractDropPolicyTest extends AbstractRouterTest {
+	
+	private String dropPolicyClass;
+
+	/**
+	 * Constructor.
+	 * @param dropPolicyClass The drop policy class name.
+	 */
+	public AbstractDropPolicyTest(String dropPolicyClass) {
+		this.dropPolicyClass = dropPolicyClass;
+	}
+	
+	/** Use three routers to do the tests **/
+	protected EpidemicRouter r0;
+	protected EpidemicRouter r1;
+	protected EpidemicRouter r2;
+	protected EpidemicRouter r3;
+	
+	@Override
+	protected void setUp() throws Exception {
+		ts.setNameSpace("Group1");
+		ts.putSetting("dropPolicy", this.dropPolicyClass);
+		//ts.putSetting("bufferSize", "3");
+		setRouterProto(new EpidemicRouter(ts));
+		super.setUp();
+		
+		// Adjust the routers references
+		r0 = (EpidemicRouter)h0.getRouter();
+		r1 = (EpidemicRouter)h1.getRouter();
+		r2 = (EpidemicRouter)h2.getRouter();
+		r3 = (EpidemicRouter)h3.getRouter();
+		
+	}
+	
+	protected void advanceWorld(int seconds) {
+		clock.advance(1);
+		updateAllNodes();
+	}
+	
+}

--- a/src/test/EDropPolicyTest.java
+++ b/src/test/EDropPolicyTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2016 Aalto University, ComNet
+ * Released under GPLv3. See LICENSE.txt for details.
+ */
+
+package test;
+
+import buffermanagement.EDropPolicy;
+import buffermanagement.FIFODropPolicy;
+import core.Message;
+
+/**
+ * Tests the basic functionality of EDropPolicy implementation.
+ */
+public class EDropPolicyTest extends AbstractDropPolicyTest {
+
+	public EDropPolicyTest() {
+		super("EDropPolicy");
+	}
+	
+	@Override
+	protected void setUp() throws Exception {
+		ts.putSetting("Group1.bufferSize", "5");
+		super.setUp();
+	}
+	
+	/**
+	 * Test the case when the buffer of the receiver is empty
+	 */
+	public void testBufferFree() {
+		assertTrue(r0.getDropPolicy() instanceof EDropPolicy);
+		
+		Message m1 = new Message(h0, h3, msgId1, 1);
+		h0.createNewMessage(m1);
+		checkCreates(1);
+		advanceWorld(1);
+		
+		h0.connect(h1);
+		advanceWorld(1);
+		
+		assertTrue(mc.next());
+		assertEquals(mc.getLastType(), mc.TYPE_START);
+		advanceWorld(1);
+		assertTrue(mc.next());
+		assertEquals(mc.getLastType(), mc.TYPE_RELAY);
+		assertEquals(mc.getLastFrom(), h0);
+		assertEquals(mc.getLastTo(), h1);
+		assertFalse(mc.getLastFirstDelivery());
+		
+		assertFalse(mc.next());
+	}
+	
+	/**
+	 * Test the case when exists a message with exact the same size of the incoming 
+	 * message and can be deleted.
+	 */
+	public void testDropEquals() {
+		
+		assertTrue(r0.getDropPolicy() instanceof EDropPolicy);
+		
+		Message m1 = new Message(h0, h1, msgId1, 1);
+		h0.createNewMessage(m1);
+		checkCreates(1);
+		advanceWorld(1);
+		
+		Message m2 = new Message(h0, h1, msgId2, 2);
+		h0.createNewMessage(m2);
+		checkCreates(1);
+		advanceWorld(1);
+		
+		Message m3 = new Message(h0, h1, msgId3, 1);
+		h0.createNewMessage(m3);
+		checkCreates(1);
+		advanceWorld(1);
+		
+		
+		Message m4 = new Message(h0, h1, msgId4, 2);
+		h0.createNewMessage(m4);
+				
+		assertTrue(mc.next());
+		assertEquals(mc.getLastType(), mc.TYPE_DELETE);
+		assertTrue(mc.getLastDropped());
+		assertFalse(h0.getMessageCollection().contains(m2));
+		checkCreates(1);
+		advanceWorld(1);
+		assertFalse(mc.next());
+		
+	}
+	
+	/**
+	 * Test the case when exists a message with the size greater than the incoming 
+	 * message and can be deleted.
+	 */
+	public void testDropGreater() {
+		
+		assertTrue(r0.getDropPolicy() instanceof EDropPolicy);
+		
+		Message m1 = new Message(h0, h1, msgId1, 1);
+		h0.createNewMessage(m1);
+		checkCreates(1);
+		advanceWorld(1);
+		
+		Message m2 = new Message(h0, h1, msgId2, 1);
+		h0.createNewMessage(m2);
+		checkCreates(1);
+		advanceWorld(1);
+		
+		Message m3 = new Message(h0, h1, msgId3, 3);
+		h0.createNewMessage(m3);
+		checkCreates(1);
+		advanceWorld(1);
+		
+		
+		Message m4 = new Message(h0, h1, msgId4, 2);
+		h0.createNewMessage(m4);
+				
+		assertTrue(mc.next());
+		assertEquals(mc.getLastType(), mc.TYPE_DELETE);
+		assertTrue(mc.getLastDropped());
+		assertFalse(h0.getMessageCollection().contains(m3));
+		checkCreates(1);
+		advanceWorld(1);
+		assertFalse(mc.next());
+		
+	}
+	
+	/**
+	 * Test the case when there is no message with size greater or equals 
+	 * the incoming message. In this situation the policy works like FIFO.
+	 */
+	public void testDropFIFO() {
+		
+		assertTrue(r0.getDropPolicy() instanceof EDropPolicy);
+		
+		Message m1 = new Message(h0, h1, msgId1, 1);
+		h0.createNewMessage(m1);
+		checkCreates(1);
+		advanceWorld(1);
+		
+		Message m2 = new Message(h0, h1, msgId2, 2);
+		h0.createNewMessage(m2);
+		checkCreates(1);
+		advanceWorld(1);
+		
+		Message m3 = new Message(h0, h1, msgId3, 2);
+		h0.createNewMessage(m3);
+		checkCreates(1);
+		advanceWorld(1);
+		
+		
+		Message m4 = new Message(h0, h1, msgId4, 3);
+		h0.createNewMessage(m4);
+				
+		assertTrue(mc.next());
+		assertEquals(mc.getLastType(), mc.TYPE_DELETE);
+		assertTrue(mc.getLastDropped());
+		assertFalse(h0.getMessageCollection().contains(m1));
+		
+		assertTrue(mc.next());
+		assertEquals(mc.getLastType(), mc.TYPE_DELETE);
+		assertTrue(mc.getLastDropped());
+		assertFalse(h0.getMessageCollection().contains(m2));
+		checkCreates(1);
+		advanceWorld(1);
+		assertFalse(mc.next());
+		
+	}
+
+}

--- a/src/test/FIFODropPolicyTest.java
+++ b/src/test/FIFODropPolicyTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2016 Aalto University, ComNet
+ * Released under GPLv3. See LICENSE.txt for details.
+ */
+
+package test;
+
+import buffermanagement.FIFODropPolicy;
+import core.Message;
+
+/**
+ * Tests the basic functionality of FIFODropPolicy implementation.
+ */
+public class FIFODropPolicyTest extends AbstractDropPolicyTest {
+
+	public FIFODropPolicyTest() {
+		super("FIFODropPolicy");
+	}
+	
+	@Override
+	protected void setUp() throws Exception {
+		ts.putSetting("Group1.bufferSize", "3");
+		super.setUp();
+	}
+	
+	/**
+	 * Test the case when the buffer of the receiver is empty
+	 */
+	public void testBufferFree() {
+		assertTrue(r0.getDropPolicy() instanceof FIFODropPolicy);
+		
+		Message m1 = new Message(h0, h3, msgId1, 1);
+		h0.createNewMessage(m1);
+		checkCreates(1);
+		advanceWorld(1);
+		
+		h0.connect(h1);
+		advanceWorld(1);
+		
+		assertTrue(mc.next());
+		assertEquals(mc.getLastType(), mc.TYPE_START);
+		advanceWorld(1);
+		assertTrue(mc.next());
+		assertEquals(mc.getLastType(), mc.TYPE_RELAY);
+		assertEquals(mc.getLastFrom(), h0);
+		assertEquals(mc.getLastTo(), h1);
+		assertFalse(mc.getLastFirstDelivery());
+	}
+	
+	/**
+	 * Test the drop logic.
+	 */
+	public void testDrop() {
+		
+		assertTrue(r0.getDropPolicy() instanceof FIFODropPolicy);
+		
+		Message m1 = new Message(h0, h1, msgId1, 1);
+		h0.createNewMessage(m1);
+		checkCreates(1);
+		advanceWorld(1);
+		
+		Message m2 = new Message(h0, h1, msgId2, 1);
+		h0.createNewMessage(m2);
+		checkCreates(1);
+		advanceWorld(1);
+		
+		Message m3 = new Message(h0, h1, msgId3, 1);
+		h0.createNewMessage(m3);
+		checkCreates(1);
+		advanceWorld(1);
+		
+		
+		Message m4 = new Message(h0, h1, msgId4, 2);
+		h0.createNewMessage(m4);
+				
+		assertTrue(mc.next());
+		assertEquals(mc.getLastType(), mc.TYPE_DELETE);
+		assertTrue(mc.getLastDropped());
+		assertFalse(h0.getMessageCollection().contains(m1));
+		
+		assertTrue(mc.next());
+		assertEquals(mc.getLastType(), mc.TYPE_DELETE);
+		assertTrue(mc.getLastDropped());
+		assertFalse(h0.getMessageCollection().contains(m2));
+		
+		
+		
+	}
+	
+}

--- a/src/test/MOFODropPolicyTest.java
+++ b/src/test/MOFODropPolicyTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2016 Aalto University, ComNet
+ * Released under GPLv3. See LICENSE.txt for details.
+ */
+
+package test;
+
+import buffermanagement.MOFODropPolicy;
+import core.Message;
+
+/**
+ * Test cases for the MOFO (Most Forwarded) drop policy implementation.
+ * @author michael
+ *
+ */
+public class MOFODropPolicyTest extends AbstractDropPolicyTest {
+
+	public MOFODropPolicyTest() {
+		super("MOFODropPolicy");
+	}
+	
+	@Override
+	protected void setUp() throws Exception {
+		ts.putSetting("Group1.bufferSize", "3");
+		super.setUp();
+	}
+	
+	/**
+	 * Test the case when the buffer of the receiver is empty
+	 */
+	public void testBufferFree() {
+		assertTrue(r0.getDropPolicy() instanceof MOFODropPolicy);
+		
+		Message m1 = new Message(h0, h3, msgId1, 1);
+		h0.createNewMessage(m1);
+		checkCreates(1);
+		advanceWorld(1);
+		
+		h0.connect(h1);
+		advanceWorld(1);
+		
+		assertTrue(mc.next());
+		assertEquals(mc.getLastType(), mc.TYPE_START);
+		advanceWorld(1);
+		assertTrue(mc.next());
+		assertEquals(mc.getLastType(), mc.TYPE_RELAY);
+		assertEquals(mc.getLastFrom(), h0);
+		assertEquals(mc.getLastTo(), h1);
+		assertFalse(mc.getLastFirstDelivery());
+	}
+	
+	/**
+	 * Test the message forward counter.
+	 */
+	public void testForwardCounter() {
+		Message m1 = new Message(h0, h1, msgId1, 1);
+		h0.createNewMessage(m1);
+		checkCreates(1);
+		updateAllNodes();
+		
+		h0.connect(h2);
+		advanceWorld(1);
+		
+		assertTrue(mc.next());
+		assertEquals(mc.getLastType(), mc.TYPE_START);
+        assertEquals(mc.getLastMsg().getId(), msgId1);
+        assertEquals(mc.getLastFrom(), h0);
+        assertEquals(mc.getLastTo(), h2);
+		
+		advanceWorld(1);
+        assertTrue(mc.next());
+        assertEquals(mc.getLastType(), mc.TYPE_RELAY);
+        assertEquals(mc.getLastFrom(), h0);
+        assertEquals(mc.getLastTo(), h2);
+        assertFalse(mc.getLastFirstDelivery());
+        
+        assertEquals(m1.getForwardCount(), 1);
+        assertEquals(((Message)h2.getMessageCollection().toArray()[0]).getForwardCount(), 0);
+        
+        disconnect(h0);
+        h0.connect(h1);
+        
+        advanceWorld(1);
+		assertTrue(mc.next());
+		assertEquals(mc.getLastType(), mc.TYPE_START);
+        assertEquals(mc.getLastMsg().getId(), msgId1);
+        assertEquals(mc.getLastFrom(), h0);
+        assertEquals(mc.getLastTo(), h1);
+		
+		advanceWorld(1);
+        
+        assertTrue(mc.next());
+        assertEquals(mc.getLastType(), mc.TYPE_RELAY);
+        assertEquals(mc.getLastFrom(), h0);
+        assertEquals(mc.getLastTo(), h1);
+        assertTrue(mc.getLastFirstDelivery());
+        
+        assertEquals(m1.getForwardCount(), 2);
+        assertEquals(((Message)h2.getMessageCollection().toArray()[0]).getForwardCount(), 0);
+        
+	}
+	
+	
+	/**
+	 * Test the basic logic of the drop policy.
+	 */
+	public void testDrop() {
+		assertTrue(r0.getDropPolicy() instanceof MOFODropPolicy);
+		
+		Message m1 = new Message(h0, h1, msgId1, 1);
+		m1.setForwardCount(2);
+		h0.createNewMessage(m1);
+		checkCreates(1);
+		advanceWorld(1);
+		
+		Message m2 = new Message(h0, h1, msgId2, 1);
+		m2.setForwardCount(1);
+		h0.createNewMessage(m2);
+		checkCreates(1);
+		advanceWorld(1);
+		
+		Message m3 = new Message(h0, h1, msgId3, 1);
+		m3.setForwardCount(3);
+		h0.createNewMessage(m3);
+		checkCreates(1);
+		advanceWorld(1);
+		
+		
+		Message m4 = new Message(h0, h1, msgId4, 2);
+		h0.createNewMessage(m4);
+				
+		assertTrue(mc.next());
+		assertEquals(mc.getLastType(), mc.TYPE_DELETE);
+		assertTrue(mc.getLastDropped());
+		assertFalse(h0.getMessageCollection().contains(m3));
+		
+		assertTrue(mc.next());
+		assertEquals(mc.getLastType(), mc.TYPE_DELETE);
+		assertTrue(mc.getLastDropped());
+		assertFalse(h0.getMessageCollection().contains(m1));
+		
+	}
+
+}

--- a/src/test/PassiveDropPolicyTest.java
+++ b/src/test/PassiveDropPolicyTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2016 Aalto University, ComNet
+ * Released under GPLv3. See LICENSE.txt for details.
+ */
+
+package test;
+
+import buffermanagement.FIFODropPolicy;
+import buffermanagement.PassiveDropPolicy;
+import core.Message;
+
+/**
+ * Test cases for the passive drop policy implementation.
+ */
+public class PassiveDropPolicyTest extends AbstractDropPolicyTest {
+
+	public PassiveDropPolicyTest() {
+		super("PassiveDropPolicy");
+	}
+	
+	@Override
+	protected void setUp() throws Exception {
+		ts.putSetting("Group1.bufferSize", "1");
+		super.setUp();
+	}
+	
+	/**
+	 * Test the case when the buffer of the receiver is empty
+	 */
+	public void testBufferFree() {
+		assertTrue(r0.getDropPolicy() instanceof PassiveDropPolicy);
+		
+		Message m1 = new Message(h0, h3, msgId1, 1);
+		h0.createNewMessage(m1);
+		checkCreates(1);
+		advanceWorld(1);
+		
+		h0.connect(h1);
+		advanceWorld(1);
+		
+		assertTrue(mc.next());
+		assertEquals(mc.getLastType(), mc.TYPE_START);
+		advanceWorld(1);
+		assertTrue(mc.next());
+		assertEquals(mc.getLastType(), mc.TYPE_RELAY);
+		assertEquals(mc.getLastFrom(), h0);
+		assertEquals(mc.getLastTo(), h1);
+		assertFalse(mc.getLastFirstDelivery());
+	}
+	
+	/**
+	 * Test the basic logic of the drop policy.
+	 */
+	public void testDontDrop() {
+		assertTrue(r0.getDropPolicy() instanceof PassiveDropPolicy);
+		
+		Message m1 = new Message(h0, h1, msgId1, 1);
+		h0.createNewMessage(m1);
+		checkCreates(1);
+		advanceWorld(1);
+		
+		Message m2 = new Message(h0, h1, msgId2, 1);
+		h0.createNewMessage(m2);
+		checkCreates(1);
+		advanceWorld(1);
+		
+		assertTrue(h0.getMessageCollection().contains(m1));
+	}
+
+}

--- a/src/test/SHLIDropPolicyTest.java
+++ b/src/test/SHLIDropPolicyTest.java
@@ -1,0 +1,82 @@
+package test;
+
+import buffermanagement.PassiveDropPolicy;
+import buffermanagement.SHLIDropPolicy;
+import core.Message;
+
+public class SHLIDropPolicyTest extends AbstractDropPolicyTest {
+
+	public SHLIDropPolicyTest() {
+		super("SHLIDropPolicy");
+	}
+	
+	@Override
+	protected void setUp() throws Exception {
+		ts.putSetting("Group.msgTtl", "100");
+		ts.putSetting("Group1.bufferSize", "3");
+		super.setUp();
+	}
+	
+	/**
+	 * Test the case when the buffer of the receiver is empty
+	 */
+	public void testBufferFree() {
+		assertTrue(r0.getDropPolicy() instanceof SHLIDropPolicy);
+		
+		Message m1 = new Message(h0, h3, msgId1, 1);
+		h0.createNewMessage(m1);
+		checkCreates(1);
+		advanceWorld(1);
+		
+		h0.connect(h1);
+		advanceWorld(1);
+		
+		assertTrue(mc.next());
+		assertEquals(mc.getLastType(), mc.TYPE_START);
+		advanceWorld(1);
+		assertTrue(mc.next());
+		assertEquals(mc.getLastType(), mc.TYPE_RELAY);
+		assertEquals(mc.getLastFrom(), h0);
+		assertEquals(mc.getLastTo(), h1);
+		assertFalse(mc.getLastFirstDelivery());
+	}
+	
+	public void testDrop() {
+		assertTrue(r0.getDropPolicy() instanceof SHLIDropPolicy);
+		
+		Message m1 = new Message(h0, h1, msgId1, 1);
+		h0.createNewMessage(m1);
+		checkCreates(1);
+		advanceWorld(1);
+		
+		Message m2 = new Message(h0, h1, msgId2, 1);
+		h0.createNewMessage(m2);
+		checkCreates(1);
+		advanceWorld(1);
+		
+		Message m3 = new Message(h0, h1, msgId3, 1);
+		h0.createNewMessage(m3);
+		checkCreates(1);
+		advanceWorld(1);
+		
+		m1.setTtl(10);
+		m2.setTtl(8);
+		m3.setTtl(7);
+		
+		
+		Message m4 = new Message(h0, h1, msgId4, 2);
+		h0.createNewMessage(m4);
+				
+		assertTrue(mc.next());
+		assertEquals(mc.getLastType(), mc.TYPE_DELETE);
+		assertTrue(mc.getLastDropped());
+		assertFalse(h0.getMessageCollection().contains(m2));
+		
+		assertTrue(mc.next());
+		assertEquals(mc.getLastType(), mc.TYPE_DELETE);
+		assertTrue(mc.getLastDropped());
+		assertFalse(h0.getMessageCollection().contains(m3));
+		
+	}
+
+}


### PR DESCRIPTION
Hi. I am using the simulator to compare message drop policies. I added this functionality in the simulator in a way that is easy to use and implement your own drop policy. 

I created an abstract class called DropPolicy with one method that needs to be implemented in order to create a new drop policy. I also added in ActiveRouter a reference to receive a drop policy implementation if it is defined in the configuration file. If you don't explicit define in the configuration file that you are using a custom drop policy, the simulator behaves as normal, without instantiating a drop policy.

For use a custom drop policy you need to use the configuration "Group.dropPolicy = EDropPolicy"  or "Group1.dropPolicy = EDropPolicy" for example. In order to implement MOFODropPolicy (Most Forwarded) I added in the Message class an attribute for counting forwards, and added in ActiveRouter a step to update this counter when a message is forwarded.

I also added unit tests for each drop policy implemented. I checked all the unit tests after implementation and all passed.

I think this functionality is quite useful. I hope it helps someone.  