### PR TITLE
Unexpected behavior: unconditional initialization with "default_settings.txt"

### DIFF
--- a/src/core/DTNSim.java
+++ b/src/core/DTNSim.java
@@ -27,6 +27,9 @@ public class DTNSim {
 	/** List of class names that should be reset between batch runs */
 	private static List<Class<?>> resetList = new ArrayList<Class<?>>();
 
+	/** file name of the default settings file ({@value}) */
+	public static final String DEF_SETTINGS_FILE ="default_settings.txt";
+
 	/**
 	 * Starts the user interface with given arguments.
 	 * If first argument is {@link #BATCH_MODE_FLAG}, the batch mode and text UI
@@ -71,7 +74,8 @@ public class DTNSim {
 			confFiles = args;
 		}
 		else {
-			confFiles = new String[] {null};
+			confFiles = new String[] { DEF_SETTINGS_FILE };
+			System.out.println("No settings file provided. Using default [" + DEF_SETTINGS_FILE + "].");
 		}
 
 		initSettings(confFiles, firstConfIndex);

--- a/src/core/Settings.java
+++ b/src/core/Settings.java
@@ -18,11 +18,7 @@ import util.Range;
 
 /**
  * Interface for simulation settings stored in setting file(s). Settings
- * class should be initialized before using (with {@link #init(String)}). If
- * Settings isn't initialized, only settings in {@link #DEF_SETTINGS_FILE}
- * are read. Normally, after initialization, settings in the given file can
- * override any settings defined in the default settings file and/or define
- * new settings.
+ * class should be initialized before using (with {@link #init(String)}).
  * <P> All settings are key-value pairs. For parsing details see
  * {@link java.util.Properties#getProperty(String)}. Value can be a single
  * value or comma separated list of values. With CSV values, CSV methods
@@ -35,8 +31,6 @@ import util.Range;
 public class Settings {
 	/** properties object where the setting files are read into */
 	protected static Properties props;
-	/** file name of the default settings file ({@value}) */
-	public static final String DEF_SETTINGS_FILE ="default_settings.txt";
 
 	/**
 	 * Setting to define the file name where all read settings are written
@@ -238,7 +232,6 @@ public class Settings {
 	 * Initializes the settings all Settings objects will use. This should be
 	 * called before any setting requests. Subsequent calls replace all
 	 * old settings and then Settings contains only the new settings.
-	 * The file {@link #DEF_SETTINGS_FILE}, if exists, is always read.
 	 * @param propFile Path to the property file where additional settings
 	 * are read from or null if no additional settings files are needed.
 	 * @throws SettingsError If loading the settings file(s) didn't succeed
@@ -246,14 +239,7 @@ public class Settings {
 	public static void init(String propFile) throws SettingsError {
 		String outFile;
 		try {
-			if (new File(DEF_SETTINGS_FILE).exists()) {
-				Properties defProperties = new Properties();
-				defProperties.load(new FileInputStream(DEF_SETTINGS_FILE));
-				props = new Properties(defProperties);
-			}
-			else {
-				props = new Properties();
-			}
+			props = new Properties();
 			if (propFile != null) {
 				props.load(new FileInputStream(propFile));
 			}


### PR DESCRIPTION
**Problem description by example**: Let `new_settings.txt` define a new scenario with two groups but only sets a default speed for both groups: `Group.speed = 0.5, 1.5`. Since there are no explicit settings for `Group1.speed` or `Group2.speed` once would expect both groups to be set to the default speed when calling `./one.sh new_settings.txt`.
This is not the case: Since `default_settings.txt` defines explicitly `Group2.speed = 2.7, 13.9`, this (specialized) setting will be applied to group 2 of `new_settings.txt` because the Properties object is defaulted with `default_settings.txt` if it exists.

This is unexpected behavior and should be removed. Note that if `default_settings.txt`is deleted or directly changed, this is not a problem. There are no warning messages whether `default_settings.txt` is used or not.

This patch does not change the default behavior of starting ONE with `default_settings.txt` if called without any arguments.