### PR TITLE
Fix bug in compareByQueueMode comparator

### DIFF
--- a/src/routing/MessageRouter.java
+++ b/src/routing/MessageRouter.java
@@ -567,8 +567,8 @@ public abstract class MessageRouter {
 	protected int compareByQueueMode(Message m1, Message m2) {
 		switch (sendQueueMode) {
 		case Q_MODE_RANDOM:
-			/* return randomly (enough) but consistently -1, 0 or 1 */
-			return (m1.hashCode()/2 + m2.hashCode()/2) % 3 - 1;
+			// return randomly (enough) but consistently
+			return Integer.compare(m1.hashCode(), m2.hashCode());
 		case Q_MODE_FIFO:
 			double diff = m1.getReceiveTime() - m2.getReceiveTime();
 			if (diff == 0) {


### PR DESCRIPTION
The compareByQueueMode is used as a comparison function for sorting. According to the API documentation on java.lang.Comparable.compareTo, the implementor must ensure that:

1. `sgn(x.compareTo(y)) == -sgn(y.compareTo(x))`, for all x and y

2. `(x.compareTo(y) > 0 && y.compareTo(z) > 0)` implies `x.compareTo(z) > 0`

3. `x.compareTo(y) == 0` implies `sgn(x.compareTo(z)) == sgn(y.compareTo(z))`, for all z

The previous implementation of compareByQueueMode violated all three conditions above. In practice, this can cause problems when sorting, resulting in a "IllegalArgumentException: Comparison method violates its general contract".

This patch fixes the compareByQueueMode method such that the three conditions given above are satisfied.