### PR TITLE
SprayAndWait: sender keeps ceil(n/2), receiver floor(n/2) copies

### DIFF
--- a/src/routing/SprayAndWaitRouter.java
+++ b/src/routing/SprayAndWaitRouter.java
@@ -63,8 +63,8 @@ public class SprayAndWaitRouter extends ActiveRouter {
 		assert nrofCopies != null : "Not a SnW message: " + msg;
 
 		if (isBinary) {
-			/* in binary S'n'W the receiving node gets ceil(n/2) copies */
-			nrofCopies = (int)Math.ceil(nrofCopies/2.0);
+			/* in binary S'n'W the receiving node gets floor(n/2) copies */
+			nrofCopies = (int)Math.floor(nrofCopies/2.0);
 		}
 		else {
 			/* in standard S'n'W the receiving node gets only single copy */
@@ -148,7 +148,8 @@ public class SprayAndWaitRouter extends ActiveRouter {
 		/* reduce the amount of copies left */
 		nrofCopies = (Integer)msg.getProperty(MSG_COUNT_PROPERTY);
 		if (isBinary) {
-			nrofCopies /= 2;
+			/* in binary S'n'W the sending node keeps ceil(n/2) copies */
+			nrofCopies = (int)Math.ceil(nrofCopies/2.0);
 		}
 		else {
 			nrofCopies--;


### PR DESCRIPTION
According to "Spyropoulos et al., _Spray and Wait: An Efficient Routing Scheme for Intermittently Connected Mobile Networks_, 2005":
> The source of a message initially starts with L copies; any node A that has n > 1 message copies (source or relay), and encounters another node B (with no copies), hands over to B ⌊n/2⌋ and keeps ⌈n/2⌉ for itself; when it is left with only one copy, it switches to direct transmission.