### PR TITLE
Created AdjencySnapshotReport

### DIFF
--- a/src/report/AdjencySnapshotReport.java
+++ b/src/report/AdjencySnapshotReport.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2017 Aalto University, ComNet
+ * Released under GPLv3. See LICENSE.txt for details.
+ * Written by Renan Greca as an extension to ONE.
+ */
+
+package report;
+
+import java.util.HashMap;
+import java.util.List;
+
+import core.ConnectionListener;
+import core.Coord;
+import core.DTNHost;
+
+/**
+ * Adjency snapshot report. Reports all pairs of nodes with active connections
+ * every configurable-amount-of-seconds (see {@link SnapshotReport#GRANULARITY}).
+ * Based on SnapshotReport, AdjencyGraphvizReport and LocationSnapshotReport.
+ */
+public class AdjencySnapshotReport extends SnapshotReport implements ConnectionListener {
+
+	private String HOST_DELIM = "<->"; // used in toString()
+	private HashMap<String, ConnectionInfo> cons;
+
+	/**
+	 * Constructor.
+	 */
+	public AdjencySnapshotReport() {
+		// this.allHosts = null;
+		init();
+	}
+
+	protected void init() {
+		super.init();
+		this.cons = new HashMap<String, ConnectionInfo>();
+	}
+
+	// Adds a connection to the list.
+	public void hostsConnected(DTNHost host1, DTNHost host2) {
+		if (isWarmup()) {
+			return;
+		}
+
+		newEvent();
+		ConnectionInfo ci = cons.get(host1+HOST_DELIM+host2);
+
+		if (ci == null) {
+			cons.put(host1+HOST_DELIM+host2, new ConnectionInfo(host1,host2));
+		}
+		else {
+			ci.nrofConnections++;
+		}
+	}
+
+	// Removes a connection from the list.
+	public void hostsDisconnected(DTNHost host1, DTNHost host2) {
+		if (isWarmup()) {
+			return;
+		}
+
+		newEvent();
+		cons.remove(host1+HOST_DELIM+host2);
+	}
+
+	// Do nothing. We're interested in the edges, not the nodes.
+	@Override 
+	protected void writeSnapshot(DTNHost host) {}
+
+	// Outputs the list of connections at each timestamp.
+	@Override
+	protected void createSnapshot(List<DTNHost> hosts) {
+		write ("[" + (int)getSimTime() + "]");
+		setPrefix("\t"); // indent following lines by one tab
+
+		for (ConnectionInfo ci : cons.values()) {
+			write(ci.h1 + " " + ci.h2);
+		}
+
+		setPrefix(""); // don't indent anymore
+	}
+
+	/**
+	 * Private class stores information of the connected hosts
+	 * and nrof times they have connected.
+	 */
+	private class ConnectionInfo {
+		private DTNHost h1;
+		private DTNHost h2;
+		private int nrofConnections;
+
+		public ConnectionInfo(DTNHost h1, DTNHost h2) {
+			this.h1 = h1;
+			this.h2 = h2;
+			this.nrofConnections = 1;
+		}
+
+		public boolean equals(Object o) {
+			if (o == null) return false;
+			return o.toString().equals(this.toString());
+		}
+
+		public int hashCode() {
+			return toString().hashCode();
+		}
+
+		public String toString() {
+			return h1+HOST_DELIM+h2;
+		}
+
+		public int compareTo(Object o) {
+			return nrofConnections - ((ConnectionInfo)o).nrofConnections;
+		}
+	}
+
+}

--- a/src/report/AdjencySnapshotReport.java
+++ b/src/report/AdjencySnapshotReport.java
@@ -71,13 +71,10 @@ public class AdjencySnapshotReport extends SnapshotReport implements ConnectionL
 	@Override
 	protected void createSnapshot(List<DTNHost> hosts) {
 		write ("[" + (int)getSimTime() + "]");
-		setPrefix("\t"); // indent following lines by one tab
 
 		for (ConnectionInfo ci : cons.values()) {
 			write(ci.h1 + " " + ci.h2);
 		}
-
-		setPrefix(""); // don't indent anymore
 	}
 
 	/**


### PR DESCRIPTION
I need ONE to simulate node mobility to use as input for a program I am developing in graduate school. Since I need agency/topology snapshots of several timestamps, I created the `AdjencySnapshotReport` module. For each timestamp, dictated by `SnapshotReport`'s granularity, it outputs the list of active connections.

Sample output:
[default_scenario_AdjencySnapshotReport.txt](https://github.com/akeranen/the-one/files/1246915/default_scenario_AdjencySnapshotReport.txt)
