### PR TITLE
Update DTNHost.java

### DIFF
--- a/src/core/DTNHost.java
+++ b/src/core/DTNHost.java
@@ -394,6 +394,7 @@ public class DTNHost implements Comparable<DTNHost> {
 			this.location.setLocation(this.destination); // snap to destination
 			possibleMovement -= distance;
 			if (!setNextWaypoint()) { // get a new waypoint
+				this.destination = null; // No more waypoints left, therefore the destination must be null
 				return; // no more waypoints left
 			}
 			distance = this.location.distance(this.destination);


### PR DESCRIPTION
In the current implementation there is a bug that appears when someone uses a movement trace file with **ExternalMovement**: at some point the positions of the nodes won't match the positions provided in the trace file. This behavior starts to happen when the **destination** property is not _null_ and the method **setNextWaypoint** (_line 396_) returns _false_ (meaning no more waypoints are available). In this situation, the next time the **DTNHost.move** method is called there will be no update to the node's next waypoint, since the **destination** property is different than _null_, preventing the simulator to run the method **setNextWaypoint** (_line 384_). The consequence of this is the occurrence of wrong values for the **destination** and **speed** properties, resulting in the simulator calculating incorrect positions for the node.