### PR TITLE
Fix attempt for a bug in DTNHost that is manifested when ExternalMovement is used

### DIFF
--- a/src/core/DTNHost.java
+++ b/src/core/DTNHost.java
@@ -394,6 +394,7 @@ public class DTNHost implements Comparable<DTNHost> {
 			this.location.setLocation(this.destination); // snap to destination
 			possibleMovement -= distance;
 			if (!setNextWaypoint()) { // get a new waypoint
+				this.destination = null; // No more waypoints left, therefore the destination must be null
 				return; // no more waypoints left
 			}
 			distance = this.location.distance(this.destination);

--- a/src/test/ExternalMovementTest.java
+++ b/src/test/ExternalMovementTest.java
@@ -64,6 +64,7 @@ public class ExternalMovementTest extends TestCase {
 		  new Coord(200,150), new Coord(230,80.8), new Coord(200,120),
 		  new Coord(150,150.5), new Coord(200, 180), new Coord(150, 250),
 		  new Coord(180, 200)}  // h2
+	};
 	private static final Coord[] STATIONARY_INPUT_COORDS = {
 		new Coord(10,10) , new Coord(20,20)
 	};

--- a/src/test/ExternalMovementTest.java
+++ b/src/test/ExternalMovementTest.java
@@ -17,7 +17,7 @@ import core.SimClock;
 public class ExternalMovementTest extends TestCase {
 	/* two nodes moving */
 	private static final String[] INPUT = {
-		"0 100 0 350 0 100 0 0",
+		"0 130 0 350 0 250 0 0",
 		"10 1 10 0",
 		"10 2 20 0",
 		"20 1 20 10",

--- a/src/test/ExternalMovementTest.java
+++ b/src/test/ExternalMovementTest.java
@@ -17,13 +17,33 @@ import core.SimClock;
 public class ExternalMovementTest extends TestCase {
 	/* two nodes moving */
 	private static final String[] INPUT = {
-		"0 30 0 350 0 100 0 0",
+		"0 100 0 350.5 0 100 0 0",
 		"10 1 10 0",
 		"10 2 20 0",
 		"20 1 20 10",
 		"20 2 300.5 10",
 		"30 1 30 10",
-		"30 2 40 100"
+		"30 2 40 100",
+		"40 1 30 30",
+		"40 2 118 150.5",
+		"50 1 25 30",
+		"50 2 250.8 100",
+		"60 1 15.5 20",
+		"60 2 280 120",
+		"70 1 0 15",
+		"70 2 200 150",
+		"80 1 0 0",
+		"80 2 230 80.8",
+		"90 1 12 8",
+		"90 2 200 120",
+		"100 1 15 15",
+		"100 2 150 150.5",
+		"110 1 40 60",
+		"110 2 200 180",
+		"120 1 20 80",
+		"120 2 150 250",
+		"130 1 30 50",
+		"130 2 180 200"
 	};
 
 	/* two stationary nodes */
@@ -34,9 +54,16 @@ public class ExternalMovementTest extends TestCase {
 	};
 
 	private static final Coord[][] INPUT_COORDS = {
-		{ new Coord(10,0), new Coord(20,10), new Coord(30,10) }, // h1
-		{ new Coord(20,0), new Coord(300.5,10), new Coord(40,100) }  // h2
-		};
+		{ new Coord(10,0),  new Coord(20,10), new Coord(30,10),
+		  new Coord(30,30), new Coord(25,30), new Coord(15.5,20),
+		  new Coord(0,15), new Coord(0,0), new Coord(12,8),
+		  new Coord(15,15), new Coord(40,60), new Coord(20,80),
+		  new Coord(30, 50)}, // h1
+		{ new Coord(20,0), new Coord(300.5,10), new Coord(40,100),
+		  new Coord(118,150.5), new Coord(250.8,100), new Coord(280,120),  
+		  new Coord(200,150), new Coord(230,80.8), new Coord(200,120),
+		  new Coord(150,150.5), new Coord(200, 180), new Coord(150, 250),
+		  new Coord(180, 200)}  // h2
 	private static final Coord[] STATIONARY_INPUT_COORDS = {
 		new Coord(10,10) , new Coord(20,20)
 	};
@@ -86,7 +113,7 @@ public class ExternalMovementTest extends TestCase {
 		assertFalse(h3.isMovementActive());
 
 		// test that h1 and h2 move according to input data
-		for (int i=0; i<INPUT_COORDS.length; i++) {
+		for (int i=0; i<INPUT_COORDS[0].length; i++) {
 			assertEquals((i+1) + ". coord of h1",
 					INPUT_COORDS[0][i], h1.getLocation());
 			assertEquals((i+1) + ". coord of h2",

--- a/src/test/ExternalMovementTest.java
+++ b/src/test/ExternalMovementTest.java
@@ -17,7 +17,7 @@ import core.SimClock;
 public class ExternalMovementTest extends TestCase {
 	/* two nodes moving */
 	private static final String[] INPUT = {
-		"0 100 0 350.5 0 100 0 0",
+		"0 100 0 350 0 100 0 0",
 		"10 1 10 0",
 		"10 2 20 0",
 		"20 1 20 10",


### PR DESCRIPTION
In the current implementation, there is a bug that appears when someone uses a movement trace file with **ExternalMovement**: at some point the positions of the nodes won't match the positions provided in the trace file. This behavior starts to happen when the **destination** property is not _null_ and the method **setNextWaypoint** (_line 396_) returns _false_ (meaning no more waypoints are available). In this situation, the next time the **DTNHost.move** method is called there will be no update to the node's next waypoint, since the **destination** property is different than _null_, preventing the simulator to run the method **setNextWaypoint** (_line 384_). The consequence of this is the occurrence of wrong values for the **destination** and **speed** properties, resulting in the simulator calculating incorrect positions for the node.

In this pull request, a correction attempt was made to **DTNHost.java**, and **ExternalMovementTest** was extended to be able to replicate the bug described above.