### PR TITLE
Suppressing serialization warnings of GUI classes

### DIFF
--- a/src/gui/EventLogControlPanel.java
+++ b/src/gui/EventLogControlPanel.java
@@ -21,6 +21,7 @@ import javax.swing.JPanel;
  * Control panel for event log
  *
  */
+@SuppressWarnings("serial")
 public class EventLogControlPanel extends JPanel implements ActionListener {
 	private static final String TITLE_TEXT = "Event log controls";
 	private static final String SHOW_TEXT = "show";

--- a/src/gui/EventLogPanel.java
+++ b/src/gui/EventLogPanel.java
@@ -29,6 +29,7 @@ import core.SimClock;
 /**
  * Event log panel where log entries are displayed.
  */
+@SuppressWarnings("serial")
 public class EventLogPanel extends JPanel
 	implements ConnectionListener, MessageListener, ActionListener {
 

--- a/src/gui/GUIControls.java
+++ b/src/gui/GUIControls.java
@@ -10,7 +10,9 @@ import java.awt.FlowLayout;
 import java.awt.Graphics2D;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+
 import javax.swing.event.*;
+
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.image.BufferedImage;
@@ -35,6 +37,7 @@ import core.SimClock;
  * GUI's control panel
  *
  */
+@SuppressWarnings("serial")
 public class GUIControls extends JPanel implements ActionListener, ChangeListener {
 	private static final String PATH_GRAPHICS = "buttonGraphics/";
 	private static final String ICON_PAUSE = "Pause16.gif";

--- a/src/gui/InfoPanel.java
+++ b/src/gui/InfoPanel.java
@@ -21,6 +21,7 @@ import core.Message;
 /**
  * Information panel that shows data of selected messages and nodes.
  */
+@SuppressWarnings("serial")
 public class InfoPanel extends JPanel implements ActionListener{
 	private JComboBox msgChooser;
 	private JLabel info;

--- a/src/gui/MainWindow.java
+++ b/src/gui/MainWindow.java
@@ -22,6 +22,7 @@ import core.World;
  * Main window for the program. Takes care of layouting the main components
  * in the window.
  */
+@SuppressWarnings("serial")
 public class MainWindow extends JFrame {
 	/** The namespace for general GUI settings */
 	public static final String GUI_NS = "GUI";

--- a/src/gui/NodeChooser.java
+++ b/src/gui/NodeChooser.java
@@ -28,6 +28,7 @@ import core.Settings;
 /**
  * Node chooser panel
  */
+@SuppressWarnings("serial")
 public class NodeChooser extends JPanel implements ActionListener {
 	private DTNSimGUI gui;
 	/** the maximum number of allNodes to show in the list per page */

--- a/src/gui/RoutingInfoWindow.java
+++ b/src/gui/RoutingInfoWindow.java
@@ -26,6 +26,7 @@ import core.SimClock;
 /**
  * A window for displaying routing information
  */
+@SuppressWarnings("serial")
 public class RoutingInfoWindow extends JFrame implements ActionListener {
 	private DTNHost host;
 	private JButton refreshButton;

--- a/src/gui/SimMenuBar.java
+++ b/src/gui/SimMenuBar.java
@@ -30,6 +30,7 @@ import core.SettingsError;
  * Menu bar of the simulator GUI
  *
  */
+@SuppressWarnings("serial")
 public class SimMenuBar extends JMenuBar implements ActionListener {
 	/** title of the about window */
 	public static final String ABOUT_TITLE = "about ONE";

--- a/src/gui/playfield/PlayField.java
+++ b/src/gui/playfield/PlayField.java
@@ -30,6 +30,7 @@ import core.World;
  * The canvas where node graphics and message visualizations are drawn.
  *
  */
+@SuppressWarnings("serial")
 public class PlayField extends JPanel {
 	public static final int PLAYFIELD_OFFSET = 10;
 


### PR DESCRIPTION
The GUI classes are never serialized so the warnings can be safely suppressed