### PR TITLE
Allow to configure whether or not connections are bidirectional

### DIFF
--- a/src/core/Connection.java
+++ b/src/core/Connection.java
@@ -64,7 +64,7 @@ public abstract class Connection {
 	 * @return true if the given node is the initiator of the connection
 	 */
 	public boolean isInitiator(DTNHost node) {
-		return node == this.fromNode;
+		return node.equals(this.fromNode);
 	}
 
 	/**
@@ -214,6 +214,13 @@ public abstract class Connection {
 		else {
 			return this.fromInterface;
 		}
+	}
+
+	/**
+	 * Returns the interface specified as originator of the connection
+	 */
+	public NetworkInterface getFromInterface() {
+		return this.fromInterface;
 	}
 
 	/**


### PR DESCRIPTION
Previously, only bidirectional connections were supported. This was
achieved by adding them to both hosts at the same time when the
NetworkInterface connected. In some cases, we have fully-independent up-
and downlink channels (or only one of them), which cannot be
simulated accurately with the default behavior.

This adds a configuration parameter "bidirectionalConnections" on a
per-interface basis, which allows to enable unidirectional connections
(by setting the parameter to false).

This also removes the check from ActiveRouter.checkReceiving whether the
current router is "transferring". This check is redundant because the
outgoing connection is already checked beforehand.
