### PR TITLE
Add setting to enable concurrent transmissions

### DIFF
--- a/src/routing/DirectDeliveryRouter.java
+++ b/src/routing/DirectDeliveryRouter.java
@@ -22,7 +22,7 @@ public class DirectDeliveryRouter extends ActiveRouter {
 	@Override
 	public void update() {
 		super.update();
-		if (isTransferring() || !canStartTransfer()) {
+		if (!canStartTransfer()) {
 			return; // can't start a new transfer
 		}
 

--- a/src/routing/EpidemicRouter.java
+++ b/src/routing/EpidemicRouter.java
@@ -34,7 +34,7 @@ public class EpidemicRouter extends ActiveRouter {
 	@Override
 	public void update() {
 		super.update();
-		if (isTransferring() || !canStartTransfer()) {
+		if (!canStartTransfer()) {
 			return; // transferring, don't try other connections yet
 		}
 

--- a/src/routing/FirstContactRouter.java
+++ b/src/routing/FirstContactRouter.java
@@ -49,7 +49,7 @@ public class FirstContactRouter extends ActiveRouter {
 	@Override
 	public void update() {
 		super.update();
-		if (isTransferring() || !canStartTransfer()) {
+		if (!canStartTransfer()) {
 			return;
 		}
 

--- a/src/routing/LifeRouter.java
+++ b/src/routing/LifeRouter.java
@@ -82,7 +82,7 @@ public class LifeRouter extends ActiveRouter {
 		Vector<String> messagesToDelete = new Vector<String>();
 		super.update();
 
-		if (isTransferring() || !canStartTransfer()) {
+		if (!canStartTransfer()) {
 			return; /* transferring, don't try other connections yet */
 		}
 

--- a/src/routing/MaxPropRouter.java
+++ b/src/routing/MaxPropRouter.java
@@ -288,7 +288,7 @@ public class MaxPropRouter extends ActiveRouter {
 	@Override
 	public void update() {
 		super.update();
-		if (!canStartTransfer() ||isTransferring()) {
+		if (!canStartTransfer()) {
 			return; // nothing to transfer or is currently transferring
 		}
 

--- a/src/routing/MaxPropRouterWithEstimation.java
+++ b/src/routing/MaxPropRouterWithEstimation.java
@@ -416,7 +416,7 @@ public class MaxPropRouterWithEstimation extends ActiveRouter {
 	@Override
 	public void update() {
 		super.update();
-		if (!canStartTransfer() ||isTransferring()) {
+		if (!canStartTransfer()) {
 			return; // nothing to transfer or is currently transferring
 		}
 

--- a/src/routing/ProphetRouter.java
+++ b/src/routing/ProphetRouter.java
@@ -210,7 +210,7 @@ public class ProphetRouter extends ActiveRouter {
 	@Override
 	public void update() {
 		super.update();
-		if (!canStartTransfer() ||isTransferring()) {
+		if (!canStartTransfer()) {
 			return; // nothing to transfer or is currently transferring
 		}
 

--- a/src/routing/ProphetRouterWithEstimation.java
+++ b/src/routing/ProphetRouterWithEstimation.java
@@ -404,7 +404,7 @@ public class ProphetRouterWithEstimation extends ActiveRouter {
 	@Override
 	public void update() {
 		super.update();
-		if (!canStartTransfer() ||isTransferring()) {
+		if (!canStartTransfer()) {
 			return; // nothing to transfer or is currently transferring
 		}
 

--- a/src/routing/ProphetV2Router.java
+++ b/src/routing/ProphetV2Router.java
@@ -262,7 +262,7 @@ public class ProphetV2Router extends ActiveRouter {
 	@Override
 	public void update() {
 		super.update();
-		if (!canStartTransfer() ||isTransferring()) {
+		if (!canStartTransfer()) {
 			return; // nothing to transfer or is currently transferring
 		}
 

--- a/src/routing/SprayAndWaitRouter.java
+++ b/src/routing/SprayAndWaitRouter.java
@@ -88,7 +88,7 @@ public class SprayAndWaitRouter extends ActiveRouter {
 	@Override
 	public void update() {
 		super.update();
-		if (!canStartTransfer() || isTransferring()) {
+		if (!canStartTransfer()) {
 			return; // nothing to transfer or is currently transferring
 		}
 

--- a/src/routing/WaveRouter.java
+++ b/src/routing/WaveRouter.java
@@ -118,7 +118,7 @@ public class WaveRouter extends ActiveRouter {
 	public void update() {
 		super.update();
 
-		if (isTransferring() || !canStartTransfer()) {
+		if (!canStartTransfer()) {
 			return; /* transferring, don't try other connections yet */
 		}
 


### PR DESCRIPTION
This adds a setting which allows nodes to transfer data on all available
connections simultaneously. (Per default, only one connection can be leveraged.)
The setting can be specified per node group.