### PR TITLE
Fixed bug that stops single event source configurations from running.

### DIFF
--- a/src/input/MessageEventGenerator.java
+++ b/src/input/MessageEventGenerator.java
@@ -31,7 +31,7 @@ public class MessageEventGenerator implements EventQueue {
 	 * selected from this range and the source hosts from the
 	 * {@link #HOST_RANGE_S} setting's range.
 	 * The lower bound is inclusive and upper bound exclusive. */
-	public static final String TO_HOST_RANGE_S = "tohosts";
+	public static final String TO_HOST_RANGE_S = "toHosts";
 
 	/** Message ID prefix -setting id ({@value}). The value must be unique
 	 * for all message sources, so if you have more than one message generator,


### PR DESCRIPTION
MessageEventGenerator had a misspelling in the `TO_HOST_RANGE_S` static string variable. Fetching `tohosts` will always return false, even when defined in the configuration, therefore not allowing you to have a valid configuration with only 1 event source and multiple destinations. 

Changing this to `toHosts` checks the properties class correctly, and will stop One from exiting with the message "Host range must contain at least two nodes unless toHostRange is defined"