### PR TITLE
fix: javac option -extdirs not allowed on windows

### DIFF
--- a/compile.bat
+++ b/compile.bat
@@ -2,7 +2,7 @@ set targetdir=target
 
 IF NOT EXIST "%targetdir%" mkdir %targetdir%
 
-javac -sourcepath src -d %targetdir% -extdirs lib/ src/core/*.java src/movement/*.java src/report/*.java src/routing/*.java src/gui/*.java src/input/*.java src/applications/*.java src/interfaces/*.java
+javac -sourcepath src -d %targetdir% -cp lib\ECLA.jar;lib\DTNConsoleConnection.jar src/core/*.java src/movement/*.java src/report/*.java src/routing/*.java src/gui/*.java src/input/*.java src/applications/*.java src/interfaces/*.java
 
 
 


### PR DESCRIPTION
issue related: 
- resolves #95
- resolves #94
- resolves #72