### PR TITLE
Add recent Docker and Docker-Compose support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM openjdk:8
+
+LABEL MAINTAINER="Marvin Raiser <marvin@raiser.dev>"
+LABEL Description="This image is used to run the ONE simulator lastest version"
+
+RUN mkdir /home/one \
+  && useradd one
+
+RUN apt-get update && apt-get install libxext6 libxrender1 libxtst6 libxi6 -y
+
+RUN  curl -sL https://codeload.github.com/akeranen/the-one/legacy.tar.gz/master \
+   | tar xvz \
+  && mv akeranen-the-one-* /home/one/the-one_latest \
+  && cd /home/one/the-one_latest \
+  && ./compile.sh \
+  && chown -R one:one /home/one
+
+WORKDIR /home/one/the-one_latest
+USER one
+
+ENTRYPOINT [ "/bin/sh", "one.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,19 +3,17 @@ FROM openjdk:8
 LABEL MAINTAINER="Marvin Raiser <marvin@raiser.dev>"
 LABEL Description="This image is used to run the ONE simulator lastest version"
 
-RUN mkdir /home/one \
-  && useradd one
+RUN useradd one
 
-RUN apt-get update && apt-get install libxext6 libxrender1 libxtst6 libxi6 -y
+WORKDIR /home/one/the-one
 
-RUN  curl -sL https://codeload.github.com/akeranen/the-one/legacy.tar.gz/master \
-   | tar xvz \
-  && mv akeranen-the-one-* /home/one/the-one_latest \
-  && cd /home/one/the-one_latest \
-  && ./compile.sh \
-  && chown -R one:one /home/one
+RUN apt-get update && apt-get install dos2unix libxext6 libxrender1 libxtst6 libxi6 -y
 
-WORKDIR /home/one/the-one_latest
-USER one
+COPY . .
+
+# Convert every file to unix line endings to prevent errors on windows
+RUN find . -type f -print0 | xargs -0 dos2unix
+
+RUN  ./compile.sh && chown -R one:one /home/one
 
 ENTRYPOINT [ "/bin/sh", "one.sh" ]

--- a/README.txt
+++ b/README.txt
@@ -57,6 +57,24 @@ read in the order given in the command line. Values in the later config files
 override values in earlier config files.
 
 
+Using Docker
+------------
+By using docker you do not need to install `java` nor play around with different versions. [See more reasons](https://stackoverflow.com/questions/34487094/why-use-docker-arent-java-files-like-war-files-already-running-on-jvm).
+
+To build the current version, from this directory execute:
+
+    docker build -t theone:latest .
+
+To run it with the GUI and share conf/data files you just need to share the socket `/tmp/.X11-unix` and the variable `DISPLAY` for the GUI, as for the conf/data files, assuming that these ones are in the `./data` folder just execute:
+
+    docker run --rm -it -e DISPLAY=$DISPLAY -v ./data:/one -v /tmp/.X11-unix:/tmp/.X11-unix theone:latest
+
+For quick start you can use `docker-compose up` to build and run the current version and `docker-compose down` to shut it down.
+If issues occur use `docker-compose up --build` to rebuild the image and run it again.
+
+Hint for Windows WSL2 users: You have to launch docker or docker-compose inside your wsl distro to get the gui running.
+
+
 Configuring
 ===========
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,12 @@
+version: "3"
+
+services:
+    theone:
+        container_name: theone
+        image: theone
+        build: .
+        environment:
+            - "DISPLAY=:0"
+        volumes:
+            - ./data:/one
+            - /tmp/.X11-unix:/tmp/.X11-unix


### PR DESCRIPTION
This PR is an updated version of the existing PR #16. It differs from it in a way that it will compile the current files instead of only version 1.6.0.

It adds:
- `Dockerfile` for building the docker image using the current version of the-one.
- `docker-compose.yaml` for easier usage of docker and configuration of the-one.

It changes the `README.txt` adding a quick start section how to use docker and docker-compose.
It also contains a hint for Windows WSL2 users.